### PR TITLE
Ensure that the validator does not raise an error if no password is provided.

### DIFF
--- a/lib/password_strength_validator/validator.rb
+++ b/lib/password_strength_validator/validator.rb
@@ -14,7 +14,7 @@ module PasswordStrengthValidator
 
   class Validator
     def initialize(password, options = {})
-      @password = password
+      parse_and_set_password(password)
       @options  = OpenStruct.new(DEFAULT_OPTIONS.merge(options))
     end
 
@@ -39,7 +39,12 @@ module PasswordStrengthValidator
     end
 
     def has_enough_symbols?
+      return false if @password.empty?
       @password.each_char.map(&:ord).select { |c| SYMBOLS.include?(c) }.size >= @options.number_of_symbols
+    end
+
+    def parse_and_set_password(password)
+      @password = password || ''
     end
   end
 end

--- a/spec/validator_spec.rb
+++ b/spec/validator_spec.rb
@@ -10,6 +10,11 @@ describe PasswordStrengthValidator::Validator do
       specify { expect(validator).to_not be_enough_length }
     end
 
+    context 'when nil' do
+      let(:password) { nil }
+      specify { expect(validator).to_not be_enough_length }
+    end
+
     context 'when too short' do
       let(:password) { 'short' }
       specify { expect(validator).to_not be_enough_length }
@@ -27,6 +32,11 @@ describe PasswordStrengthValidator::Validator do
   end
 
   describe '#has_uppercase?' do
+    context 'when nil' do
+      let(:password) { nil }
+      specify { expect(validator).to_not be_has_uppercase }
+    end
+
     context 'only lowercase' do
       let(:password) { 'onlylowercase' }
       specify { expect(validator).to_not be_has_uppercase }
@@ -50,6 +60,11 @@ describe PasswordStrengthValidator::Validator do
   end
 
   describe '#has_lowercase?' do
+    context 'when nil' do
+      let(:password) { nil }
+      specify { expect(validator).to_not be_has_lowercase }
+    end
+
     context 'only lowercase' do
       let(:password) { 'onlylowercase' }
       specify { expect(validator).to be_has_lowercase }
@@ -73,6 +88,11 @@ describe PasswordStrengthValidator::Validator do
   end
 
   describe '#has_enought_digits?' do
+    context 'when nil' do
+      let(:password) { nil }
+      specify { expect(validator).to_not be_has_enough_digits }
+    end
+
     context 'without any digits' do
       let(:password) { 'LongEnoughtWithoutDigits' }
       specify { expect(validator).to_not be_has_enough_digits }
@@ -97,6 +117,11 @@ describe PasswordStrengthValidator::Validator do
   end
 
   describe '#has_enough_symbols?' do
+    context 'when nil' do
+      let(:password) { nil }
+      specify { expect(validator).to_not be_has_enough_symbols }
+    end
+
     context 'without any symbols' do
       let(:password) { 'LongEnoughtWithoutSymbols' }
 


### PR DESCRIPTION
Howdy kwappa,

We received an error when attempting to create a user without a password. Ideally the errors attribute would be populated on the `User` instance, but instead an error was raised.

Specifically we were seeing:

``` ruby
undefined method `length' for nil:NilClass
```

The source of this error was from `lib/password_strength_validator/validator.rb:26:in 'enough_length?'`

We are providing this patch to avoid this error from being raised.

Note: in our context `password` is a "virtual attribute" defined by `authlogic`. AuthLogic is the authentication gem we are using for handling encryption.

Thanks!
